### PR TITLE
Hide: No such file or directory error

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 python3 generate.py
 python3 shuffle.py $1
 python3 sound.py temp_output.mp4 result.mp4
-rm temp_output.mp4
+rm temp_output.mp4 2>/dev/null


### PR DESCRIPTION
When terms were not accepted the `temp_output.mp4` file does not exist and you get an error message at the end. This hides the error.